### PR TITLE
Responsive Hamburger Menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import Grid from "./Components/Grid/Grid";
 import { IExpenseData } from "./shared/interfaces";
+import HamburgerMenu from "./Components/HamburgerMenu/HamburgerMenu";
 
 const App = () => {
   const [rowData, setRowData] = useState<IExpenseData[]>([]);
@@ -121,6 +122,7 @@ const App = () => {
 
   return (
     <div>
+      <HamburgerMenu />
       <Paper
         sx={{
           border: "1px solid rgb(186, 186, 186)",

--- a/src/Components/HamburgerMenu/HamburgerMenu.tsx
+++ b/src/Components/HamburgerMenu/HamburgerMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import {
   Drawer,
   IconButton,
@@ -7,6 +7,7 @@ import {
   ListItemText,
   Box,
   Stack,
+  ListItemButton,
 } from "@mui/material";
 import MenuIcon from "@mui/icons-material/Menu";
 
@@ -41,18 +42,19 @@ const HamburgerMenu = () => {
         >
           <List>
             {menuOptions.map((option) => (
-              <ListItem
-                key={option.id}
-                button
-                sx={{
-                  backgroundColor: "#fff",
-                  "&:hover": {
-                    cursor: "pointer",
-                  },
-                  border: "none",
-                }}
-              >
-                <ListItemText primary={option.label} />
+              <ListItem key={option.id} disablePadding>
+                <ListItemButton
+                  onClick={() => {
+                    setOpen(false); // close drawer when clicking item
+                  }}
+                  sx={{
+                    backgroundColor: "#fff",
+                    "&:hover": { cursor: "pointer" },
+                    border: "none",
+                  }}
+                >
+                  <ListItemText primary={option.label} />
+                </ListItemButton>
               </ListItem>
             ))}
           </List>

--- a/src/Components/HamburgerMenu/HamburgerMenu.tsx
+++ b/src/Components/HamburgerMenu/HamburgerMenu.tsx
@@ -1,5 +1,4 @@
-// src/Components/HamburgerMenu/HamburgerMenu.tsx
-import { useState } from "react";
+import React, { useState } from "react";
 import {
   Drawer,
   IconButton,
@@ -7,6 +6,7 @@ import {
   ListItem,
   ListItemText,
   Box,
+  Stack,
 } from "@mui/material";
 import MenuIcon from "@mui/icons-material/Menu";
 
@@ -14,16 +14,22 @@ const menuOptions = [{ id: "inicio", label: "INICIO" }];
 
 const HamburgerMenu = () => {
   const [open, setOpen] = useState(false);
-
-  const toggleDrawer = (state: boolean) => () => {
-    setOpen(state);
-  };
+  const toggleDrawer = (state: boolean) => () => setOpen(state);
 
   return (
-    <Box>
-      <IconButton onClick={toggleDrawer(true)} color="inherit">
-        <MenuIcon />
-      </IconButton>
+    <>
+      {/* Mobile: Hamburger Button */}
+      <Box
+        sx={{
+          display: { xs: "block", md: "none" },
+        }}
+      >
+        <IconButton onClick={toggleDrawer(true)} color="inherit">
+          <MenuIcon />
+        </IconButton>
+      </Box>
+
+      {/* Mobile: Drawer Menu */}
       <Drawer anchor="left" open={open} onClose={toggleDrawer(false)}>
         <Box
           sx={{
@@ -38,7 +44,6 @@ const HamburgerMenu = () => {
               <ListItem
                 key={option.id}
                 button
-                component="button"
                 sx={{
                   backgroundColor: "#fff",
                   "&:hover": {
@@ -53,7 +58,34 @@ const HamburgerMenu = () => {
           </List>
         </Box>
       </Drawer>
-    </Box>
+
+      {/* Desktop: Horizontal Menu */}
+      <Stack
+        direction="row"
+        spacing={2}
+        sx={{
+          display: { xs: "none", md: "flex" },
+        }}
+      >
+        {menuOptions.map((option) => (
+          <Box
+            key={option.id}
+            component="button"
+            sx={{
+              background: "none",
+              border: "none",
+              padding: "16px 16px",
+              fontSize: "1rem",
+              fontWeight: 500,
+              color: "#1976d2",
+              cursor: "pointer",
+            }}
+          >
+            {option.label}
+          </Box>
+        ))}
+      </Stack>
+    </>
   );
 };
 

--- a/src/Components/HamburgerMenu/HamburgerMenu.tsx
+++ b/src/Components/HamburgerMenu/HamburgerMenu.tsx
@@ -23,6 +23,11 @@ const HamburgerMenu = () => {
       <Box
         sx={{
           display: { xs: "block", md: "none" },
+          boxShadow: "rgba(0, 0, 0, 0.2) 0px 3px 6px",
+          margin: "0 0 15px 0",
+          borderBottomRightRadius: "5px",
+          borderBottomLeftRadius: "5px",
+          borderBottom: "1px solid #d5d5d5",
         }}
       >
         <IconButton onClick={toggleDrawer(true)} color="inherit">
@@ -67,6 +72,11 @@ const HamburgerMenu = () => {
         spacing={2}
         sx={{
           display: { xs: "none", md: "flex" },
+          boxShadow: "rgba(0, 0, 0, 0.2) 0px 3px 6px",
+          margin: "0 0 15px 0",
+          borderBottomRightRadius: "5px",
+          borderBottomLeftRadius: "5px",
+          borderBottom: "1px solid #d5d5d5",
         }}
       >
         {menuOptions.map((option) => (

--- a/src/Components/HamburgerMenu/HamburgerMenu.tsx
+++ b/src/Components/HamburgerMenu/HamburgerMenu.tsx
@@ -1,0 +1,60 @@
+// src/Components/HamburgerMenu/HamburgerMenu.tsx
+import { useState } from "react";
+import {
+  Drawer,
+  IconButton,
+  List,
+  ListItem,
+  ListItemText,
+  Box,
+} from "@mui/material";
+import MenuIcon from "@mui/icons-material/Menu";
+
+const menuOptions = [{ id: "inicio", label: "INICIO" }];
+
+const HamburgerMenu = () => {
+  const [open, setOpen] = useState(false);
+
+  const toggleDrawer = (state: boolean) => () => {
+    setOpen(state);
+  };
+
+  return (
+    <Box>
+      <IconButton onClick={toggleDrawer(true)} color="inherit">
+        <MenuIcon />
+      </IconButton>
+      <Drawer anchor="left" open={open} onClose={toggleDrawer(false)}>
+        <Box
+          sx={{
+            width: 250,
+            height: "100%",
+          }}
+          role="presentation"
+          onClick={toggleDrawer(false)}
+        >
+          <List>
+            {menuOptions.map((option) => (
+              <ListItem
+                key={option.id}
+                button
+                component="button"
+                sx={{
+                  backgroundColor: "#fff",
+                  "&:hover": {
+                    cursor: "pointer",
+                  },
+                  border: "none",
+                }}
+              >
+                <ListItemText primary={option.label} />
+              </ListItem>
+            ))}
+          </List>
+        </Box>
+      </Drawer>
+    </Box>
+  );
+};
+
+export default HamburgerMenu;


### PR DESCRIPTION
## Feature: Responsive Hamburger Menu

This PR adds a responsive navigation menu to improve usability across devices:

- 📱 On mobile: introduces a hamburger button that opens a drawer with an "INICIO" option.
- 🖥️ On desktop: displays the menu options horizontally in the header.

### Breakpoint Threshold

-  Hamburger menu appears on screens less than 960px wide (xs to sm).
-  Horizontal menu appears on screens 960px and wider (md and up).
<img width="575" height="642" alt="Screenshot 2025-10-12 144802" src="https://github.com/user-attachments/assets/6e8e38a8-c88a-4e2a-95d2-ba7f79f176d2" />

<img width="555" height="636" alt="Screenshot 2025-10-12 144753" src="https://github.com/user-attachments/assets/cf3e64e4-a9ff-4e41-befd-e3d0c3be532c" />
<img width="943" height="643" alt="Screenshot 2025-10-12 144738" src="https://github.com/user-attachments/assets/7c8b4a23-d457-45c1-b969-dfb259ce9f55" />



Closes #4
